### PR TITLE
fix(languages): add `make` as an alias for `makefile`

### DIFF
--- a/src/modelines.ts
+++ b/src/modelines.ts
@@ -234,6 +234,7 @@ function translateLanguageName(lang: string|undefined): string {
 		case 'csh':
 		case 'bash':
 			return 'shellscript';
+		case 'make':
 		case 'makefile-gmake':
 			return 'makefile';
 		default:


### PR DESCRIPTION
VSCode's filetype for Makefiles is `makefile` but Vim's is `make`. Add a translation.

Note I had to apply #25 to get this to load properly.
